### PR TITLE
Soporte a Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>org.javassist</groupId>
 			<artifactId>javassist</artifactId>
-			<version>3.15.0-GA</version>
+			<version>3.18.2-GA</version>
 		</dependency>
 		<dependency>
 			<groupId>xmlpull</groupId>


### PR DESCRIPTION
Javassist 3.18.2-GA (Mayo, 2014) es la primera
con soporte java 8.

Ver http://stackoverflow.com/questions/30313255/reflections-java-8-invalid-constant-type